### PR TITLE
Self-host fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.3",
+        "@fontsource-variable/jetbrains-mono": "^5.3.0",
+        "@fontsource-variable/space-grotesk": "^5.3.0",
         "astro": "^5.0.0",
         "sharp": "^0.35.3"
       },
@@ -589,6 +591,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/space-grotesk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.3.0.tgz",
+      "integrity": "sha512-2IxmvfB08i9vnGB3Ym/AXvhRE+8XOjWMXIyDum03c+tPwH0FUoMNQfGpU8NXPxjbws0Vvss3AH0Zqt4oJBBAdw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
+    "@fontsource-variable/jetbrains-mono": "^5.3.0",
+    "@fontsource-variable/space-grotesk": "^5.3.0",
     "astro": "^5.0.0",
     "sharp": "^0.35.3"
   },

--- a/src/components/BlogSection.astro
+++ b/src/components/BlogSection.astro
@@ -90,7 +90,7 @@ const formatDate = (date: Date) =>
 }
 
 .post-date {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
     color: var(--text-secondary);
 }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -75,7 +75,7 @@ import { Image } from 'astro:assets';
 }
 
 .company-name {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: clamp(14px, 1.5vw, 18px);
     font-weight: 400;
     letter-spacing: 0.1em;

--- a/src/components/Team.astro
+++ b/src/components/Team.astro
@@ -32,7 +32,7 @@ const team = [
 
 <style>
 .team-subtitle {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: 16px;
     color: var(--primary);
     text-transform: uppercase;
@@ -145,7 +145,7 @@ const team = [
 }
 
 .member-role {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
     text-transform: uppercase;
     letter-spacing: 0.08em;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,4 +1,8 @@
 ---
+import '@fontsource-variable/space-grotesk';
+import '@fontsource-variable/jetbrains-mono';
+import spaceGroteskWoff2 from '@fontsource-variable/space-grotesk/files/space-grotesk-latin-wght-normal.woff2?url';
+import jetbrainsMonoWoff2 from '@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2?url';
 import '../styles/global.css';
 
 interface Props {
@@ -38,9 +42,8 @@ const ogImage = new URL('/og.png', Astro.site);
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="1RG Labs logo">
     <meta name="twitter:card" content="summary_large_image">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600&family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="preload" as="font" type="font/woff2" crossorigin href={spaceGroteskWoff2}>
+    <link rel="preload" as="font" type="font/woff2" crossorigin href={jetbrainsMonoWoff2}>
 </head>
 <body>
     <div class="noise"></div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -42,7 +42,7 @@ const formatDate = (date: Date) =>
 }
 
 .back-link {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -65,7 +65,7 @@ const formatDate = (date: Date) =>
 }
 
 .post-date {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
     color: var(--text-secondary);
 }
@@ -133,7 +133,7 @@ const formatDate = (date: Date) =>
 }
 
 .prose :global(code) {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: 0.9em;
     background: rgba(117, 71, 219, 0.1);
     padding: 2px 6px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,10 +15,14 @@
     --bg-darker: #020617;
     --text-primary: #F9FAFB;
     --text-secondary: #9CA3AF;
+    /* self-hosted variable fonts, registered by the @fontsource-variable
+       imports in Base.astro */
+    --font-sans: 'Space Grotesk Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: 'JetBrains Mono Variable', ui-monospace, monospace;
 }
 
 body {
-    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(--font-sans);
     background-color: var(--bg-dark);
     color: var(--text-primary);
     overflow-x: hidden;


### PR DESCRIPTION
## Summary

Replaces the render-blocking Google Fonts stylesheet with self-hosted variable fonts via `@fontsource-variable`.

- One woff2 per family (latin subsets: Space Grotesk 24kB, JetBrains Mono 40kB), covering every weight the site uses; other-script subsets load only if the page ever needs them
- Files are bundled and content-hashed by the build (long-lived caching) and preloaded from the layout, so text renders without waiting on a `fonts.googleapis.com` → `fonts.gstatic.com` request chain
- No third-party requests left on the site at all
- Font families now live behind `--font-sans` / `--font-mono` tokens in `global.css` instead of being repeated in eight places

Verified in a built copy: `document.fonts` reports both variable faces loaded, and the rendered page is visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)